### PR TITLE
Cleanup Jade templates; separate blocks for content, templates, scripts

### DIFF
--- a/views/components/characterInfo.jade
+++ b/views/components/characterInfo.jade
@@ -1,7 +1,4 @@
-doctype html
-html
-
-  script(type="text/html" id="character-info")
-   p= "dude, this may have worked"  
-   ul(id="characters-list")
-     div#grid   
+#character-info
+	p= "dude, this may have worked"  
+	ul#characters-list
+		#grid

--- a/views/components/login.jade
+++ b/views/components/login.jade
@@ -1,16 +1,12 @@
-doctype html
-html
-
-  script(type="text/html" id="template-login")
-    h1 Login
-    form(id="login" action="/login" method="post")
-      h1 Username :
-      input(id="username" name="username" type="text" required)
-      h1 Password :
-      input(id="password" name="password" type="password" required)
-      br
-      br
-      input(id="loginButton" type="submit" value="Login")
-      a( id="loadSignup" action="/signup" class="hvr-grow")
-        p dont have an account?
-      
+#login-container
+	h1 Login
+	form#login(action="/login" method="post")
+		h1 Username :
+		input#username(name="username" type="text" required)
+		h1 Password :
+		input#password(name="password" type="password" required)
+		br
+		br
+		input#loginButton(type="submit" value="Login")
+		a#loadSignup(action="/signup" class="hvr-grow")
+			p dont have an account?

--- a/views/components/main.jade
+++ b/views/components/main.jade
@@ -1,4 +1,0 @@
-doctype html
-html
-
-  div(id="comicapp")

--- a/views/components/select.jade
+++ b/views/components/select.jade
@@ -1,14 +1,7 @@
-doctype html
-html
-
- div(id="characters")
- 
- script(type="text/html" id="template-characterSelect")
-  ul(id="character")
-    li(class="character" data-character-id="1")
-    li(class="character" data-character-id="2")
-    li(class="character" data-character-id="3")
-    li(class="character" data-character-id="4")
-    li(class="character" data-character-id="5")
-    li(class="character" data-character-id="6")
-  
+ul(id="characters")
+	li.character(data-character-id="1")
+	li.character(data-character-id="2")
+	li.character(data-character-id="3")
+	li.character(data-character-id="4")
+	li.character(data-character-id="5")
+	li.character(data-character-id="6")

--- a/views/components/signup.jade
+++ b/views/components/signup.jade
@@ -1,15 +1,12 @@
-doctype html
-html
-
-  script(type="text/html" id="template-signup")
-   h1 Sign Up
-   form(id="signup" action="/signup" method="post")
-     h1 Pick Username :
-     input(id="username" name="username" type="text" required)
-     h1 Password :
-     input(id="password" name="password" type="password" required)
-     br
-     br
-     input(id= "signupButton" type="submit" value="Signup")
-     a(id="loadLogin" action="/login" class="hvr-grow")
-       p already have an account?
+#signup-container
+	h1 Sign Up
+	form#signup(action="/signup" method="post")
+		h1 Pick Username :
+		input#username(name="username" type="text" required)
+		h1 Password :
+		input#password(name="password" type="password" required)
+		br
+		br
+		input#signupButton(type="submit" value="Signup")
+		a#loadLogin(action="/login" class="hvr-grow")
+			p already have an account?

--- a/views/index.jade
+++ b/views/index.jade
@@ -1,25 +1,20 @@
 extends layout
+
 block content
+	h1 Welcome to Nerd Battle 2015
+	div.title
+		p= message
 
- h1 Welcome to Nerd Battle 2015
- div.title
-   p= message
-   
- include components/login.jade
- include components/signup.jade
- include components/select.jade
- include components/characterInfo.jade
+	#comicapp.login
 
- div.login(id="comicapp")
- 
- script(type="text/html" id="template-login")
- script(type="text/html" id="template-signup")
- script(type="text/html" id="template-characterSelect")
- script(type="text/html" id="character-info")
- 
- script(type='text/javascript' src='../javascripts/jquery-2.1.4.js')
- script(type='text/javascript' src='../javascripts/underscore.js')
- script(type='text/javascript' src='../javascripts/backbone.js')
- script(type='text/javascript' src='../javascripts/comicApp.js')
- script(rel='stylesheet', href='../stylesheets/normalize.css')
- script(rel='stylesheet', href='../stylesheets/style.css')
+block templates
+	script(type="text/html")#template-login: include components/login.jade
+	script(type="text/html")#template-signup: include components/signup.jade
+	script(type="text/html")#template-characterSelect: include components/select.jade
+	script(type="text/html")#character-info: include components/characterInfo.jade
+
+block scripts
+	script(type='text/javascript' src='../javascripts/jquery-2.1.4.js')
+	script(type='text/javascript' src='../javascripts/underscore.js')
+	script(type='text/javascript' src='../javascripts/backbone.js')
+	script(type='text/javascript' src='../javascripts/comicApp.js')

--- a/views/layout.jade
+++ b/views/layout.jade
@@ -1,10 +1,12 @@
 doctype html
 html
-  head
-    title= title
-    link(rel='stylesheet', href='/stylesheets/style.css')
-    script(rel='stylesheet', href='../stylesheets/normalize.css')
-    link(href='http://fonts.googleapis.com/css?family=Bangers' rel='stylesheet' type='text/css')
-    link(href="/stylesheets/hover.css" rel="stylesheet" media="all")
-  body
-    block content
+	head
+		title= title
+		link(rel='stylesheet', href='/stylesheets/style.css')
+		script(rel='stylesheet', href='../stylesheets/normalize.css')
+		link(href='http://fonts.googleapis.com/css?family=Bangers' rel='stylesheet' type='text/css')
+		link(href="/stylesheets/hover.css" rel="stylesheet" media="all")
+	body
+		block content
+		block templates
+		block scripts

--- a/views/main.jade
+++ b/views/main.jade
@@ -1,5 +1,0 @@
-
-extends layout 
-
-block content
-  head


### PR DESCRIPTION
I tried to put similar pieces of code together and created a separate Jade block for each. The multiple Jade blocks are functionally identical to what was there before but it helps to create a more self-documenting markup file.

I put the script tags and includes in the right spot so that the includes go inside the script tags. Inside `components` you do not need to declare an html and body tag because they aren't ever rendered on their own.

Adding an ID to an element in a Jade file is as easy at adding a `#id-of-tag` to it. If you want to ID a `div` then you don't even need to write `div` (shown in `login.jade`). This notation puts it more in-line with CSS & jQuery and so makes find/replace across your codebase much easier.